### PR TITLE
Removing genomes parameter causing warning

### DIFF
--- a/lib/WorkflowIridanextexample.groovy
+++ b/lib/WorkflowIridanextexample.groovy
@@ -12,7 +12,6 @@ class WorkflowIridanextExample {
     //
     public static void initialise(params, log) {
 
-        genomeExistsError(params, log)
     }
 
     public static String toolCitationText(params) {
@@ -61,19 +60,5 @@ class WorkflowIridanextExample {
         def description_html = engine.createTemplate(methods_text).make(meta)
 
         return description_html
-    }
-
-    //
-    // Exit pipeline if incorrect --genome key provided
-    //
-    private static void genomeExistsError(params, log) {
-        if (params.genomes && params.genome && !params.genomes.containsKey(params.genome)) {
-            def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
-                "  Genome '${params.genome}' not found in any config files provided to the pipeline.\n" +
-                "  Currently, the available genome keys are:\n" +
-                "  ${params.genomes.keySet().join(", ")}\n" +
-                "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-            Nextflow.error(error_string)
-        }
     }
 }

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -46,15 +46,4 @@ class WorkflowMain {
             Nextflow.error("Please provide an input samplesheet to the pipeline e.g. '--input samplesheet.csv'")
         }
     }
-    //
-    // Get attribute from genome config file e.g. fasta
-    //
-    public static Object getGenomeAttribute(params, attribute) {
-        if (params.genomes && params.genome && params.genomes.containsKey(params.genome)) {
-            if (params.genomes[ params.genome ].containsKey(attribute)) {
-                return params.genomes[ params.genome ][ attribute ]
-            }
-        }
-        return null
-    }
 }


### PR DESCRIPTION
I noticed there was vestigial code referencing `params.genomes` and it was generating a warning. I've tried to remove it here.