### PR TITLE
Fix typo in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 1.0.2 - 2023/12/18
 
 - Removed GitHub workflows that weren't needed.
 - Adding additional parameters for testing purposes.

--- a/nextflow.config
+++ b/nextflow.config
@@ -196,7 +196,7 @@ manifest {
     description     = """IRIDA Next Example Pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.0.2dev'
+    version         = '1.0.2'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
Merge dev into main with fix of typo for `README.md` 