### PR TITLE
Pin version of nf-validation #26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.3 - 2024/02/23
+
+- Pinned nf-validation@1.1.3 plugin
+
 ## 1.0.2 - 2023/12/18
 
 - Removed GitHub workflows that weren't needed.

--- a/nextflow.config
+++ b/nextflow.config
@@ -154,7 +154,7 @@ singularity.registry = 'quay.io'
 
 // Nextflow plugins
 plugins {
-    id 'nf-validation' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-validation@1.1.3' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
@@ -196,7 +196,7 @@ manifest {
     description     = """IRIDA Next Example Pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.0.2'
+    version         = '1.0.3'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
<!--
# phac-nml/iridanextexample pull request

Many thanks for contributing to phac-nml/iridanextexample!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/phac-nml/iridanextexample/tree/main/.github/CONTRIBUTING.md)
-->

PR in response to the following issue:
Pin version of nf-validation #26 

The nextflow.config file has been updated to pin a specific version for nf-validation:
- nf-validation@1.1.3

Pinning a specific version of the Nextflow plugin will circumvent breaking changes associated with the recent upgrade of the nf-validation plugin from 1.1.3 to 2.0.0.
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

