### PR TITLE
Update: Container Registry

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,13 +14,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5
+      - name: Set up Python 3.12
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
-          python-version: 3.11
-          cache: "pip"
+          python-version: "3.12"
 
       - name: Install pre-commit
         run: pip install pre-commit
@@ -32,14 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
 
       - name: Install Nextflow
-        uses: nf-core/setup-nextflow@v1
+        uses: nf-core/setup-nextflow@v2
 
-      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           architecture: "x64"
 
       - name: Install dependencies
@@ -60,7 +59,7 @@ jobs:
 
       - name: Upload linting log file artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
           name: linting-logs
           path: |

--- a/.github/workflows/linting_comment.yml
+++ b/.github/workflows/linting_comment.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download lint results
-        uses: dawidd6/action-download-artifact@f6b0bace624032e30a85a8fd9c1a7f8f611f5737 # v3
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3
         with:
           workflow: linting.yml
           workflow_conclusion: completed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ternary conditional operator in container section of process directive for singularity containers
 - Replaced docker.io as default docker container registry for quay.io/biocontainers
 
-## 1.0.3 - 2024/02/23
+## [1.0.3]- 2024/02/23
 
 - Pinned nf-validation@1.1.3 plugin
 
-## 1.0.2 - 2023/12/18
+## [1.0.2] - 2023/12/18
 
 - Removed GitHub workflows that weren't needed.
 - Adding additional parameters for testing purposes.
 
-## 1.0.1 - 2023/12/06
+## [1.0.1] - 2023/12/06
 
 Allowing non-gzipped FASTQ files as input. Default branch is now main.
 
-## 1.0.0 - 2023/11/30
+## [1.0.0] - 2023/11/30
 
 Initial release of phac-nml/iridanextexample, created with the [nf-core](https://nf-co.re/) template.
 
@@ -34,3 +34,8 @@ Initial release of phac-nml/iridanextexample, created with the [nf-core](https:/
 ### `Dependencies`
 
 ### `Deprecated`
+
+[1.0.3]: https://github.com/phac-nml/iridanextexample/releases/tag/1.0.3
+[1.0.2]: https://github.com/phac-nml/iridanextexample/releases/tag/1.0.2
+[1.0.1]: https://github.com/phac-nml/iridanextexample/releases/tag/1.0.1
+[1.0.0]: https://github.com/phac-nml/iridanextexample/releases/tag/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## In-development
 
-- Fixed nf-core tools linting failures introduced in version 2.12.1.
+- Fixed nf-core tools linting failures introduced in version 2.14.1.
 - Added phac-nml prefix to nf-core config
+- Added ternary conditional operator in container section of process directive for singularity containers
+- Replaced docker.io as default docker container registry for quay.io/biocontainers
 
 ## 1.0.3 - 2024/02/23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed nf-core tools linting failures introduced in version 2.14.1.
 - Added phac-nml prefix to nf-core config
-- Added ternary conditional operator in container section of process directive for singularity containers
-- Replaced docker.io as default docker container registry for quay.io/biocontainers
+- Updated container directives to meet requirements of [phac-nml pipeline standards software requirements]
+  - Added ternary conditional operator in container section of process directive for singularity containers
+  - Replaced docker.io as default docker container registry for quay.io/biocontainers
+  - Implemented an example of [overriding container registries with the container directive]
 
 ## [1.0.3]- 2024/02/23
 
@@ -35,6 +37,8 @@ Initial release of phac-nml/iridanextexample, created with the [nf-core](https:/
 
 ### `Deprecated`
 
+[Overriding container registries with the container directive]: https://github.com/phac-nml/pipeline-standards?tab=readme-ov-file#521-module-software-requirements
+[phac-nml pipeline standards software requirements]: https://github.com/phac-nml/pipeline-standards?tab=readme-ov-file#521-module-software-requirements
 [1.0.3]: https://github.com/phac-nml/iridanextexample/releases/tag/1.0.3
 [1.0.2]: https://github.com/phac-nml/iridanextexample/releases/tag/1.0.2
 [1.0.1]: https://github.com/phac-nml/iridanextexample/releases/tag/1.0.1

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ nextflow run phac-nml/iridanextexample -profile singularity -r main -latest --in
 ```
 
 Where the `samplesheet.csv` is structured as specified in the [Input](#input) section.
+For more information see [usage doc](docs/usage.md)
 
 # Output
 
@@ -84,6 +85,8 @@ An example of the what the contents of the IRIDA Next JSON file looks like for t
 Within the `files` section of this JSON file, all of the output paths are relative to the `outdir`. Therefore, `"path": "assembly/SAMPLE1.assembly.fa.gz"` refers to a file located within `outdir/assembly/SAMPLE1.assembly.fa.gz`.
 
 There is also a pipeline execution summary output file provided (specified in the above JSON as `"global": [{"path":"summary/summary.txt.gz"}]`). However, there is no formatting specification for this file.
+
+For more information see [output doc](docs/output.md)
 
 ## Test profile
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The structure of this file is defined in [assets/schema_input.json](assets/schem
 
 The main parameters are `--input` as defined above and `--output` for specifying the output results directory. You may wish to provide `-profile singularity` to specify the use of singularity containers and `-r [branch]` to specify which GitHub branch you would like to run.
 
-Other parameters (defaults from nf-core) are defined in [nextflow_schema.json](nextflow_schmea.json).
+Other parameters (defaults from nf-core) are defined in [nextflow_schema.json](nextflow_schema.json).
 
 # Running
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,6 +61,7 @@ Do not use `-c <file>` to specify parameters as this will result in errors. Cust
 ### Overriding Container Registries with the `container` Directive
 
 The `iridanextexample` has implemented the process `override_configured_container_registry` ([detailed here](https://github.com/phac-nml/pipeline-standards?tab=readme-ov-file#5221-example-overriding-container-registries-with-the-container-directive)) to allow `docker.io` to be used when default registry is `quay.io` to [customize the container](#custom-containers) for the [process](/modules/local/simplifyiridajson/main.nf) `SIMPLIFY_IRIDA_JSON`. The process can be changed in the [nextflow.config](/./nextflow.config#L158)
+
 ```bash
 // Override the default Docker registry when required
 process.ext.override_configured_container_registry = true

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,7 +57,14 @@ If you wish to repeatedly use the same parameters for multiple runs, rather than
 Pipeline settings can be provided in a `yaml` or `json` file via `-params-file <file>`.
 
 Do not use `-c <file>` to specify parameters as this will result in errors. Custom config files specified with `-c` must only be used for [tuning process resource specifications](https://nf-co.re/docs/usage/configuration#tuning-workflow-resources), other infrastructural tweaks (such as output directories), or module arguments (args).
-:::
+
+### Overriding Container Registries with the `container` Directive
+
+The `iridanextexample` has implemented the process `override_configured_container_registry` ([detailed here](https://github.com/phac-nml/pipeline-standards?tab=readme-ov-file#5221-example-overriding-container-registries-with-the-container-directive)) to allow `docker.io` to be used when default registry is `quay.io` to [customize the container](#custom-containers) for the [process](/modules/local/simplifyiridajson/main.nf) `SIMPLIFY_IRIDA_JSON`. The process can be changed in the [nextflow.config](/./nextflow.config#L158)
+```bash
+// Override the default Docker registry when required
+process.ext.override_configured_container_registry = true
+```
 
 The above pipeline run specified with a params file in yaml format:
 

--- a/modules/local/assemblystub/main.nf
+++ b/modules/local/assemblystub/main.nf
@@ -2,7 +2,9 @@ process ASSEMBLY_STUB {
     tag "$meta.id"
     label 'process_single'
 
-    container 'docker.io/python:3.9.17'
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.10' :
+        'biocontainers/python:3.10' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/local/generatesamplejson/main.nf
+++ b/modules/local/generatesamplejson/main.nf
@@ -2,7 +2,9 @@ process GENERATE_SAMPLE_JSON {
     tag "$meta.id"
     label 'process_single'
 
-    container 'docker.io/python:3.9.17'
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.10' :
+        'biocontainers/python:3.10' }"
 
     input:
     tuple val(meta), path(reads), path(assembly)

--- a/modules/local/generatesummary/main.nf
+++ b/modules/local/generatesummary/main.nf
@@ -1,6 +1,8 @@
 process GENERATE_SUMMARY {
     label 'process_single'
-    container 'docker.io/python:3.9.17'
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.10' :
+        'biocontainers/python:3.10' }"
 
     input:
     val summaries

--- a/modules/local/iridanextoutput/main.nf
+++ b/modules/local/iridanextoutput/main.nf
@@ -1,7 +1,9 @@
 process IRIDA_NEXT_OUTPUT {
     label 'process_single'
 
-    container 'docker.io/python:3.9.17'
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.10' :
+        'biocontainers/python:3.10' }"
 
     input:
     path(samples_data)

--- a/modules/local/simplifyiridajson/main.nf
+++ b/modules/local/simplifyiridajson/main.nf
@@ -3,13 +3,11 @@ process SIMPLIFY_IRIDA_JSON {
     label 'process_single'
 
     // Container directive is intentionally using the "override_configure_container_registry" as an example:
-    // How to keep a non-biocontainer/quay.io default, see nextflow.config for
+    // How to keep a non-biocontainer/quay.io default, see nextflow.config for details
 
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/python:3.10' :
-    task.ext.override_configured_container_registry != false ?
+    container "${ task.ext.override_configured_container_registry != false ?
     'docker.io/python:3.10' :
-    'biocontainers/python:3.10' }"
+    'python:3.10' }"
 
     input:
     tuple val(meta), path(json)

--- a/modules/local/simplifyiridajson/main.nf
+++ b/modules/local/simplifyiridajson/main.nf
@@ -2,7 +2,14 @@ process SIMPLIFY_IRIDA_JSON {
     tag "$meta.id"
     label 'process_single'
 
-    container 'docker.io/python:3.9.17'
+    // Container directive is intentionally using the "override_configure_container_registry" as an example:
+    // How to keep a non-biocontainer/quay.io default, see nextflow.config for
+
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    'https://depot.galaxyproject.org/singularity/python:3.10' :
+    task.ext.override_configured_container_registry != false ?
+    'docker.io/python:3.10' :
+    'biocontainers/python:3.10' }"
 
     input:
     tuple val(meta), path(json)

--- a/nextflow.config
+++ b/nextflow.config
@@ -154,6 +154,9 @@ docker.registry      = 'quay.io'
 podman.registry      = 'quay.io'
 singularity.registry = 'quay.io'
 
+// Override the default Docker registry when required
+process.ext.override_configured_container_registry = true
+
 // Nextflow plugins
 plugins {
     id 'nf-validation@1.1.3' // Validation of pipeline parameters and creation of an input channel from a sample sheet


### PR DESCRIPTION
Going to make two changes to the `iridanextexample` pipeline:

First, we are changing all the `docker.io/python` containers to use the [biocontainers](https://biocontainers.pro/tools/python) on quay.io for all the phac-nml nextflow pipelines to align more closely with `nf-core` standards. Implementing this change to affected processe, while also updating the style of the container section in the process directives to follow the format:
```bash
"${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
        'https://depot.galaxyproject.org/singularity/python:3.8.3' :
        'biocontainers/python:3.8.3' }"
```

The second change, will be to implement and example of [overriding container registries within the `container` directive](https://github.com/phac-nml/pipeline-standards?tab=readme-ov-file#5221-example-overriding-container-registries-with-the-container-directive)
```bash
container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
    'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
    task.ext.override_configured_container_registry != false ?
    'docker.io/biocontainers/fastqc:v0.11.9_cv8' :
    'biocontainers/fastqc:0.11.9--0' }"
```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
