### PR TITLE
Fix version number in manifest

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -204,7 +204,7 @@ manifest {
     description     = """IRIDA Next Example Pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.0.3'
+    version         = '1.0.4'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
In the 1.0.4 patch release the version listed in the nextflow.config manifest section was not updated.